### PR TITLE
fix: prevent scrolling while edit profile

### DIFF
--- a/src/routes/profile/[username]/+page.svelte
+++ b/src/routes/profile/[username]/+page.svelte
@@ -2,6 +2,7 @@
 	import { deserialize } from '$app/forms'
 	import { goto } from '$app/navigation'
 	import { resolve } from '$app/paths'
+	import { onDestroy } from 'svelte'
 	import SideNav from '$lib/components/SideNav.svelte'
 	import Post from '$lib/components/Post.svelte'
 	import RightSidebar from '$lib/components/RightSidebar.svelte'
@@ -45,6 +46,17 @@
 	let is_bio_updating = $state(false)
 	let avatar_url_at_save = ''
 	let banner_url_at_save = ''
+
+	$effect(() => {
+		if (typeof document !== 'undefined') {
+			if (is_edit_modal_open) {
+				document.body.style.overflow = 'hidden'
+			} else {
+				document.body.style.overflow = ''
+			}
+		}
+	})
+
 	let toast = $state<{
 		type: 'success' | 'error'
 		message: string
@@ -67,6 +79,12 @@
 		if (data.profile.avatar_url === avatar_url_at_save) is_avatar_updating = false
 		if (data.profile.banner_url === banner_url_at_save) is_banner_updating = false
 		is_bio_updating = false
+	})
+
+	onDestroy(() => {
+		if (typeof document !== 'undefined') {
+			document.body.style.overflow = ''
+		}
 	})
 
 	function get_safe_count(count: number) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll locking behavior in the profile edit modal. When you open the modal, page scrolling is now properly disabled to keep your focus entirely on the modal form. When you close it, scrolling is automatically restored to its normal state, allowing you to continue navigating and exploring the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->