### PR TITLE
fix: add heic and heif into allowed mime types

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -47,3 +47,4 @@ words:
   - heim
   - heix
   - ftyp
+  - recognised

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -42,3 +42,8 @@ words:
   - addrs
   - ilike
   - Unfollowing
+  - heis
+  - hevx
+  - heim
+  - heix
+  - ftyp

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"esbuild",
-			"lefthook"
+			"lefthook",
+			"sharp"
 		],
 		"ignoredBuiltDependencies": [
 			"@prisma/client",
@@ -93,6 +94,7 @@
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.1.18",
 		"@types/node": "^22",
+		"@types/sharp": "^0.32.0",
 		"better-auth": "1.4.22",
 		"cspell": "^9.7.0",
 		"drizzle-kit": "^0.31.8",
@@ -123,6 +125,7 @@
 	"dependencies": {
 		"@better-auth/infra": "^0.1.13",
 		"@better-auth/sso": "1.4.22",
-		"cloudinary": "^2.9.0"
+		"cloudinary": "^2.9.0",
+		"sharp": "^0.34.5"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       cloudinary:
         specifier: ^2.9.0
         version: 2.9.0
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
     devDependencies:
       '@better-auth/cli':
         specifier: ~1.4.22
@@ -70,6 +73,9 @@ importers:
       '@types/node':
         specifier: ^22
         version: 22.19.15
+      '@types/sharp':
+        specifier: ^0.32.0
+        version: 0.32.0
       better-auth:
         specifier: 1.4.22
         version: 1.4.22(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.54.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.14)(pg@8.20.0))(pg@8.20.0)(svelte@5.54.1)(vitest@4.1.0)
@@ -606,6 +612,9 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
     deprecated: 'Merged into tsx: https://tsx.is'
@@ -836,6 +845,159 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -1222,6 +1384,10 @@ packages:
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/sharp@0.32.0':
+    resolution: {integrity: sha512-OOi3kL+FZDnPhVzsfD37J88FNeZh6gQsGcLc95NbeURRGvmSjeXiDcyWzF2o3yh/gQAUn2uhh/e+CPCa5nwAxw==}
+    deprecated: This is a stub types definition. sharp provides its own type definitions, so you do not need this installed.
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2812,6 +2978,10 @@ packages:
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2962,6 +3132,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -3803,6 +3976,11 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
       esbuild: 0.27.4
@@ -3957,6 +4135,102 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -4265,6 +4539,10 @@ snapshots:
       '@types/node': 22.19.15
       pg-protocol: 1.13.0
       pg-types: 2.2.0
+
+  '@types/sharp@0.32.0':
+    dependencies:
+      sharp: 0.34.5
 
   '@types/trusted-types@2.0.7': {}
 
@@ -5695,6 +5973,37 @@ snapshots:
 
   set-cookie-parser@3.1.0: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -5857,6 +6166,9 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.21.0:
     dependencies:

--- a/src/routes/home/+page.server.ts
+++ b/src/routes/home/+page.server.ts
@@ -19,7 +19,15 @@ const CREATE_POST_LIMIT = { limit: 5, windowMs: 60_000 }
 const TOGGLE_LIKE_LIMIT = { limit: 30, windowMs: 60_000 }
 const TOGGLE_FOLLOW_LIMIT = { limit: 15, windowMs: 60_000 }
 const WHO_TO_FOLLOW_LIMIT = 6
-const ALLOWED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp'])
+const ALLOWED_IMAGE_MIME_TYPES = new Set([
+	'image/jpeg',
+	'image/png',
+	'image/gif',
+	'image/webp',
+	'image/heic',
+	'image/heif'
+])
+const HEIF_MIME_TYPES = new Set(['image/heic', 'image/heif'])
 
 type UploadedPostImage = {
 	url: string
@@ -83,11 +91,32 @@ const is_webp = (buffer: Buffer) =>
 	buffer.subarray(8, 12).toString('ascii') === 'WEBP' &&
 	['VP8 ', 'VP8L', 'VP8X'].includes(buffer.subarray(12, 16).toString('ascii'))
 
+const HEIC_BRANDS = new Set(['heic', 'heis', 'hevc', 'hevx', 'heim', 'heix'])
+const HEIF_BRANDS = new Set(['mif1', 'msf1'])
+
+const get_heif_brand = (buffer: Buffer): string | undefined => {
+	if (buffer.length < 12) return undefined
+	if (buffer.subarray(4, 8).toString('ascii') !== 'ftyp') return undefined
+	return buffer.subarray(8, 12).toString('ascii')
+}
+
+const is_heic = (buffer: Buffer) => {
+	const brand = get_heif_brand(buffer)
+	return brand !== undefined && HEIC_BRANDS.has(brand)
+}
+
+const is_heif = (buffer: Buffer) => {
+	const brand = get_heif_brand(buffer)
+	return brand !== undefined && HEIF_BRANDS.has(brand)
+}
+
 const get_image_mime_type = (buffer: Buffer) => {
 	if (is_png(buffer)) return 'image/png'
 	if (is_jpeg(buffer)) return 'image/jpeg'
 	if (is_gif(buffer)) return 'image/gif'
 	if (is_webp(buffer)) return 'image/webp'
+	if (is_heic(buffer)) return 'image/heic'
+	if (is_heif(buffer)) return 'image/heif'
 
 	return undefined
 }
@@ -104,17 +133,25 @@ const validate_post_image = async (
 	const mime_type = get_image_mime_type(buffer)
 
 	if (!mime_type || !ALLOWED_IMAGE_MIME_TYPES.has(mime_type)) {
-		return { error: 'Only JPEG, PNG, GIF, and WebP images are supported' }
+		return { error: 'Only JPEG, PNG, GIF, WebP, and HEIC/HEIF images are supported' }
 	}
 
-	if (file.type && file.type !== mime_type) {
+	// heic and heif are interchangeable from the browser's perspective
+	const type_mismatch =
+		file.type &&
+		file.type !== mime_type &&
+		!(HEIF_MIME_TYPES.has(file.type) && HEIF_MIME_TYPES.has(mime_type))
+	if (type_mismatch) {
 		return { error: 'Image type does not match the uploaded file contents' }
 	}
 
-	return {
-		buffer,
-		mime_type
+	if (HEIF_MIME_TYPES.has(mime_type)) {
+		const { default: sharp } = await import('sharp')
+		const jpeg_buffer = await sharp(buffer).jpeg({ quality: 90 }).toBuffer()
+		return { buffer: jpeg_buffer, mime_type: 'image/jpeg' }
 	}
+
+	return { buffer, mime_type }
 }
 
 const upload_post_image = async (image: ValidatedImageUpload) => {
@@ -316,17 +353,26 @@ export const actions: Actions = {
 			return fail(payload.error.status, { message: payload.error.message })
 		}
 
-		const validated_image = payload.image_file
-			? await validate_post_image(payload.image_file)
-			: undefined
-		if (validated_image && 'error' in validated_image) {
-			console.warn('[createPost] image validation rejected', {
-				file_name: payload.image_file?.name,
-				file_type: payload.image_file?.type,
-				file_size: payload.image_file?.size,
-				reason: validated_image.error
-			})
-			return fail(400, { message: validated_image.error })
+		let validated_image: ValidatedImageUpload | undefined
+
+		if (payload.image_file) {
+			let validation_result: Awaited<ReturnType<typeof validate_post_image>>
+			try {
+				validation_result = await validate_post_image(payload.image_file)
+			} catch (error) {
+				console.error('[createPost] image validation threw:', error)
+				return fail(500, { message: 'Internal server error' })
+			}
+			if ('error' in validation_result) {
+				console.warn('[createPost] image validation rejected', {
+					file_name: payload.image_file.name,
+					file_type: payload.image_file.type,
+					file_size: payload.image_file.size,
+					reason: validation_result.error
+				})
+				return fail(400, { message: validation_result.error })
+			}
+			validated_image = validation_result
 		}
 
 		let uploaded_image: Awaited<ReturnType<typeof get_post_image_url>>

--- a/src/routes/home/+page.server.ts
+++ b/src/routes/home/+page.server.ts
@@ -94,10 +94,19 @@ const is_webp = (buffer: Buffer) =>
 const HEIC_BRANDS = new Set(['heic', 'heis', 'hevc', 'hevx', 'heim', 'heix'])
 const HEIF_BRANDS = new Set(['mif1', 'msf1'])
 
+const ALL_HEIF_BRANDS = new Set([...HEIC_BRANDS, ...HEIF_BRANDS])
+
 const get_heif_brand = (buffer: Buffer): string | undefined => {
 	if (buffer.length < 12) return undefined
 	if (buffer.subarray(4, 8).toString('ascii') !== 'ftyp') return undefined
-	return buffer.subarray(8, 12).toString('ascii')
+	const major = buffer.subarray(8, 12).toString('ascii')
+	if (ALL_HEIF_BRANDS.has(major)) return major
+	// Scan compatible_brands (bytes 16+, 4 bytes each) for a recognised brand.
+	for (let offset = 16; offset + 4 <= buffer.length; offset += 4) {
+		const brand = buffer.subarray(offset, offset + 4).toString('ascii')
+		if (ALL_HEIF_BRANDS.has(brand)) return brand
+	}
+	return undefined
 }
 
 const is_heic = (buffer: Buffer) => {
@@ -147,7 +156,7 @@ const validate_post_image = async (
 
 	if (HEIF_MIME_TYPES.has(mime_type)) {
 		const { default: sharp } = await import('sharp')
-		const jpeg_buffer = await sharp(buffer).jpeg({ quality: 90 }).toBuffer()
+		const jpeg_buffer = await sharp(buffer).autoOrient().jpeg({ quality: 90 }).toBuffer()
 		return { buffer: jpeg_buffer, mime_type: 'image/jpeg' }
 	}
 

--- a/src/routes/home/+page.svelte
+++ b/src/routes/home/+page.svelte
@@ -243,7 +243,10 @@
 			return
 		}
 
-		if (!ALLOWED_IMAGE_MIME_TYPES.has(file.type)) {
+		const lower_name = file.name.toLowerCase()
+		const is_heif_by_extension =
+			file.type === '' && (lower_name.endsWith('.heic') || lower_name.endsWith('.heif'))
+		if (!is_heif_by_extension && !ALLOWED_IMAGE_MIME_TYPES.has(file.type)) {
 			clear_selected_image(composer_form ?? undefined)
 			show_toast('error', 'Only JPEG, PNG, GIF, WebP, and HEIC/HEIF images are supported')
 			return

--- a/src/routes/home/+page.svelte
+++ b/src/routes/home/+page.svelte
@@ -60,7 +60,14 @@
 	// Character limit constants
 	const MAX_POST_LENGTH = 280
 	const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
-	const ALLOWED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp'])
+	const ALLOWED_IMAGE_MIME_TYPES = new Set([
+		'image/jpeg',
+		'image/png',
+		'image/gif',
+		'image/webp',
+		'image/heic',
+		'image/heif'
+	])
 
 	function get_safe_count(count: number | string | undefined) {
 		const parsed_count = Number(count ?? 0)
@@ -238,7 +245,7 @@
 
 		if (!ALLOWED_IMAGE_MIME_TYPES.has(file.type)) {
 			clear_selected_image(composer_form ?? undefined)
-			show_toast('error', 'Only JPEG, PNG, GIF, and WebP images are supported')
+			show_toast('error', 'Only JPEG, PNG, GIF, WebP, and HEIC/HEIF images are supported')
 			return
 		}
 
@@ -426,13 +433,19 @@
 					id="composer-image"
 					type="file"
 					name="image"
-					accept="image/*"
+					accept="image/jpeg,image/png,image/gif,image/webp,image/heic,image/heif,.heic,.heif"
 					class="composer-file-input"
 					onchange={handle_image_change}
 				/>
 				{#if selected_image_preview}
 					<div class="composer-image-preview">
-						<img src={selected_image_preview} alt="Selected attachment preview" />
+						<img
+							src={selected_image_preview}
+							alt="Selected attachment preview"
+							onerror={(e) => {
+								;(e.currentTarget as HTMLImageElement).style.display = 'none'
+							}}
+						/>
 						<div class="composer-image-meta">
 							<span>{selected_image_name}</span>
 							<button


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HEIC and HEIF image formats alongside existing JPEG, PNG, GIF, and WebP. HEIC/HEIF images are automatically converted for seamless uploading.
  * Improved image preview reliability with error handling for unsupported formats.

* **Chores**
  * Updated build and development configuration for image processing support.
  * Added custom words to spell-check configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->