### PR TITLE
fix: prevent scrolling on mobile specificallt IOS safari when psotmod…

### DIFF
--- a/src/lib/components/PostModal.svelte
+++ b/src/lib/components/PostModal.svelte
@@ -53,15 +53,19 @@
 
 	$effect(() => {
 		const scroll_y = window.scrollY
+		const prior_overflow = document.body.style.overflow
+		const prior_position = document.body.style.position
+		const prior_top = document.body.style.top
+		const prior_width = document.body.style.width
 		document.body.style.overflow = 'hidden'
 		document.body.style.position = 'fixed'
 		document.body.style.top = `-${scroll_y}px`
 		document.body.style.width = '100%'
 		return () => {
-			document.body.style.overflow = ''
-			document.body.style.position = ''
-			document.body.style.top = ''
-			document.body.style.width = ''
+			document.body.style.overflow = prior_overflow
+			document.body.style.position = prior_position
+			document.body.style.top = prior_top
+			document.body.style.width = prior_width
 			window.scrollTo(0, scroll_y)
 		}
 	})

--- a/src/lib/components/PostModal.svelte
+++ b/src/lib/components/PostModal.svelte
@@ -52,9 +52,17 @@
 	}
 
 	$effect(() => {
+		const scroll_y = window.scrollY
 		document.body.style.overflow = 'hidden'
+		document.body.style.position = 'fixed'
+		document.body.style.top = `-${scroll_y}px`
+		document.body.style.width = '100%'
 		return () => {
 			document.body.style.overflow = ''
+			document.body.style.position = ''
+			document.body.style.top = ''
+			document.body.style.width = ''
+			window.scrollTo(0, scroll_y)
 		}
 	})
 
@@ -373,6 +381,8 @@
 		z-index: 200;
 		background: rgba(0, 0, 0, 0.92);
 		animation: modal-fade 0.18s ease-out;
+		touch-action: none;
+		overscroll-behavior: none;
 	}
 
 	@keyframes modal-fade {


### PR DESCRIPTION
…al is triggered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal scroll handling to preserve the user's scroll position when the modal opens and closes
  * Enhanced backdrop interaction by disabling touch gesture handling and preventing overscroll behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->